### PR TITLE
Adding support for Tajik, Uzbek, Kazakh, Kyrgyz and Turkmen

### DIFF
--- a/ordia/app/templates/text_to_lexemes.html
+++ b/ordia/app/templates/text_to_lexemes.html
@@ -98,14 +98,19 @@ ORDER BY ?word
  	    <option value="eu"{% if text_language == 'eu' %} selected="selected"{% endif %}>Euskara</option>
 	    <option value="fr"{% if text_language == 'fr' %} selected="selected"{% endif %}>Français</option>
 	    <option value="hi"{% if text_language == 'hi' %} selected="selected"{% endif %}>हिन्दी</option>
+	    <option value="kk"{% if text_language == 'kk' %} selected="selected"{% endif %}>Қазақша</option>
 	    <option value="kl"{% if text_language == 'kl' %} selected="selected"{% endif %}>kalaallisut</option>
 	    <option value="ku"{% if text_language == 'ku' %} selected="selected"{% endif %}>kurdî</option>
+	    <option value="ky"{% if text_language == 'ky' %} selected="selected"{% endif %}>Кыргызча</option>
 	    <option value="mis-x-Q36846"{% if text_language == 'mis-x-Q36846' %} selected="selected"{% endif %}>Toki Pona</option>
 	    <option value="ml"{% if text_language == 'ml' %} selected="selected"{% endif %}>മലയാളം</option>
 	    <option value="pa"{% if text_language == 'pa' %} selected="selected"{% endif %}>ਪੰਜਾਬੀ</option>
 	    <option value="pl"{% if text_language == 'pl' %} selected="selected"{% endif %}>Polski</option>
 	    <option value="pt"{% if text_language == 'pt' %} selected="selected"{% endif %}>Português</option>
 	    <option value="sv"{% if text_language == 'sv' %} selected="selected"{% endif %}>Svenska</option>
+	    <option value="tg"{% if text_language == 'tg' %} selected="selected"{% endif %}>Тоҷикӣ</option>
+	    <option value="tk"{% if text_language == 'tk' %} selected="selected"{% endif %}>Türkmençe</option>
+	    <option value="uz"{% if text_language == 'uz' %} selected="selected"{% endif %}>Oʻzbekcha</option>
 	    <option value="vi"{% if text_language == 'vi' %} selected="selected"{% endif %}>Tiếng Việt</option>
 	</select>
     </div>


### PR DESCRIPTION
All of these languages can be written in more than one script, and I do not know how best to handle that, so for the moment, I went with the script that is the default on the respective language code Wikipedia.

Also, I sorted them into the list by their language code but this may not be the most user-friendly way of doing it once the list gets longer.