### PR TITLE
Updated Punjabi language labels

### DIFF
--- a/ordia/app/templates/text_to_lexemes.html
+++ b/ordia/app/templates/text_to_lexemes.html
@@ -127,9 +127,9 @@ ORDER BY ?word
 	  <option value="nn"{% if text_language == 'nn' %} selected="selected"{% endif %}>norsk nynorsk - nn - Norwegian Nynorsk</option>
 	  <option value="nv"{% if text_language == 'nv' %} selected="selected"{% endif %}>Diné bizaad - nv - Navajo</option>
 	  <option value="or"{% if text_language == 'or' %} selected="selected"{% endif %}>ଓଡ଼ିଆ - or - Ordia</option>
-	  <option value="pa"{% if text_language == 'pa' %} selected="selected"{% endif %}>ਪੰਜਾਬੀ - pa - Eastern Punjabi</option>
+	  <option value="pa"{% if text_language == 'pa' %} selected="selected"{% endif %}>ਪੰਜਾਬੀ - pa - Punjabi Gurmukhi</option>
 	  <option value="pl"{% if text_language == 'pl' %} selected="selected"{% endif %}>Polski - pl - Polish</option>
-	  <option value="pnb"{% if text_language == 'pnb' %} selected="selected"{% endif %}>پن٘جابی - pnb - Western Punjabi</option>
+	  <option value="pnb"{% if text_language == 'pnb' %} selected="selected"{% endif %}>پن٘جابی - pnb - Punjabi Shahmukhi</option>
 	  <option value="pt"{% if text_language == 'pt' %} selected="selected"{% endif %}>Português - pt - Portuguese</option>
 	  <option value="ru"{% if text_language == 'ru' %} selected="selected"{% endif %}>Русский - ru - Russian</option>
 	  <option value="sk"{% if text_language == 'sk' %} selected="selected"{% endif %}>Slovenčina - sk - Slovak</option>


### PR DESCRIPTION
On the text to lexemes page, this changes "Eastern Punjabi" to "Punjabi Gurmukhi" and "Western Punjabi" to "Punjabi Shahmukhi." These language can only be understood to refer to these two different scripts for written Punjabi rather than any regional variation, and Punjabi lexemes typically include both on each head word as spelling variants. This would just make these options a bit easier to find in the menu when I add lexemes.