### PR TITLE
adjusting srsearch string in wiktionarySparql

### DIFF
--- a/ordia/app/templates/lf.html
+++ b/ordia/app/templates/lf.html
@@ -193,7 +193,7 @@ LIMIT 50
   SERVICE wikibase:mwapi {
       bd:serviceParam wikibase:api "Search" .
       bd:serviceParam wikibase:endpoint "{{ iso639 }}.wiktionary.org" .
-      bd:serviceParam mwapi:srsearch "{{ representation }}" .
+      bd:serviceParam mwapi:srsearch "\\"{{ representation }}\\"" .
       bd:serviceParam mwapi:language "{{ iso639 }}" .
       ?title wikibase:apiOutput mwapi:title .
       ?snippet_ wikibase:apiOutput "@snippet" .


### PR DESCRIPTION
Closes #141 .

Adjusted the search string to yield more precise matches.

Before example for https://ordia.toolforge.org/L10213-F1 : 

![Screenshot from 2022-07-07 11-35-47](https://user-images.githubusercontent.com/465923/177743009-626bf22a-6d2d-4595-a590-81a6626b013b.png)

After &mdash; some of the entries (e.g. the ```actinoporins``` and ```chemical shift``` ones) are not listed any more:

![Screenshot from 2022-07-07 11-36-12](https://user-images.githubusercontent.com/465923/177743004-017c76c5-83fd-46e3-af5b-8ed586a31d06.png)

