### PR TITLE
Fix regex to allow multiple combining characters

### DIFF
--- a/ordia/text.py
+++ b/ordia/text.py
@@ -9,7 +9,7 @@ sentence_split_pattern = regex.compile(
     r"(?<=[\.!?:])\s",
     flags=regex.UNICODE | regex.DOTALL)
 word_pattern = regex.compile(
-    r"((?:\p{L}\p{M}?)+(?:-(?:\p{L}\p{M}?)+)*)",
+    r"((?:\p{L}\p{M}*)+(?:-(?:\p{L}\p{M}*)+)*)",
     flags=regex.UNICODE)
 
 


### PR DESCRIPTION
There's no limit on how many combining characters can be added to a letter and
some orthographies make use of 2 [1], 3 [2] or possibly even more.
This fixes #144.

[1] https://en.wiktionary.org/wiki/%E1%9E%80%E1%9E%BB%E1%9F%86
[2] https://en.wiktionary.org/wiki/%E0%BD%A6%E0%BE%A6%E0%BE%B1%E0%BD%B2%E0%BD%93