### PR TITLE
Fetch lexeme languages from the API

### DIFF
--- a/ordia/api.py
+++ b/ordia/api.py
@@ -12,6 +12,11 @@ Options:
 
 import requests
 
+try:
+    from functools import lru_cache
+except ImportError:
+    # For Python 2.
+    from functools32 import lru_cache
 
 HEADERS = {
     'User-Agent': 'Ordia',
@@ -78,6 +83,28 @@ def wb_get_entities(ids):
                 break
 
     return entities
+
+
+def wb_content_languages():
+    params = {
+        'action': 'query',
+        'format': 'json',
+        'meta': 'wbcontentlanguages',
+        'wbclcontext': 'term-lexicographical',
+        'wbclprop': 'code|name|autonym',
+    }
+
+    response = requests.get(
+        'https://www.wikidata.org/w/api.php',
+        headers=HEADERS, params=params)
+
+    response_data = response.json()
+    return response_data['query']['wbcontentlanguages']
+
+
+@lru_cache(maxsize=None)
+def wb_content_languages_cached():
+	return wb_content_languages()
 
 
 def wb_search_lexeme_entities(query, language='en'):

--- a/ordia/app/templates/text_to_lexemes.html
+++ b/ordia/app/templates/text_to_lexemes.html
@@ -87,67 +87,18 @@ ORDER BY ?word
     </div>
     <div class="form-row">
       <div class="form-group col-md-6">
-	<label for="language">Language:</label>
-	<select class="form-control" id="language-selector" name="text-language">
-	  <option value="ar"{% if text_language == 'ar' %} selected="selected"{% endif %}>العربية - ar - Arabic</option>
-	  <option value="bg"{% if text_language == 'bg' %} selected="selected"{% endif %}>Български - bg - Bulgarian</option>
-	  <option value="bho"{% if text_language == 'bho' %} selected="selected"{% endif %}>𑂦𑂷𑂔𑂣𑂳𑂩𑂲 - bho - Bhojpuri</option>
-	  <option value="bn"{% if text_language == 'bn' %} selected="selected"{% endif %}>বাংলা - bn - Bengali</option>
-	  <option value="br"{% if text_language == 'br' %} selected="selected"{% endif %}>Brezhoneg - br - Breton</option>
-	  <option value="cs"{% if text_language == 'cs' %} selected="selected"{% endif %}>Čeština - cs - Czech</option>
-	  <option value="da"{% if text_language == 'da' %} selected="selected"{% endif %}>Dansk - da - Danish</option>
-	  <option value="de"{% if text_language == 'de' %} selected="selected"{% endif %}>Deutsch - de - German</option>
-	  <option value="el"{% if text_language == 'el' %} selected="selected"{% endif %}>ελληνικά - el - Greek</option>
- 	  <option value="en"{% if text_language == 'en' %} selected="selected"{% endif %}>English - en - English</option>
- 	  <option value="eo"{% if text_language == 'eo' %} selected="selected"{% endif %}>Esperanto - eo - Esperanto</option>
- 	  <option value="es"{% if text_language == 'es' %} selected="selected"{% endif %}>Español - es - Spanish</option>
- 	  <option value="et"{% if text_language == 'et' %} selected="selected"{% endif %}>Eesti - et - Estonian</option>
- 	  <option value="eu"{% if text_language == 'eu' %} selected="selected"{% endif %}>Euskara - eu - Basque</option>
-	  <option value="fa"{% if text_language == 'fa' %} selected="selected"{% endif %}>فارسی - fa - Persian</option>
-	  <option value="fi"{% if text_language == 'fi' %} selected="selected"{% endif %}>Suomen - fi - Finnish</option>
-	  <option value="fo"{% if text_language == 'fo' %} selected="selected"{% endif %}>Føroyskt - fo - Faroese</option>
-	  <option value="fr"{% if text_language == 'fr' %} selected="selected"{% endif %}>Français - fr - French</option>
-	  <option value="gu"{% if text_language == 'gu' %} selected="selected"{% endif %}>ગુજરાતી - gu - Gujarati</option>
-	  <option value="hi"{% if text_language == 'hi' %} selected="selected"{% endif %}>हिन्दी - hi - Hindi</option>
-	  <option value="it"{% if text_language == 'it' %} selected="selected"{% endif %}>Italiano - it - Italian</option>
-	  <option value="ja"{% if text_language == 'ja' %} selected="selected"{% endif %}>日本語 - ja - Japanese</option>
-	  <option value="kk"{% if text_language == 'kk' %} selected="selected"{% endif %}>Қазақша - kk - Kazakh</option>
-	  <option value="kl"{% if text_language == 'kl' %} selected="selected"{% endif %}>kalaallisut - kl - Greenlandic</option>
-	  <option value="kn"{% if text_language == 'kn' %} selected="selected"{% endif %}>ಕನ್ನಡ - kn - Kannada</option>
-	  <option value="ko"{% if text_language == 'ko' %} selected="selected"{% endif %}>한국어 - ko - Korean</option>
-	  <option value="ku"{% if text_language == 'ku' %} selected="selected"{% endif %}>kurdî - ku - Kurdish</option>
-	  <option value="ky"{% if text_language == 'ky' %} selected="selected"{% endif %}>Кыргызча - ky - Kyrghyz</option>
-	  <option value="la"{% if text_language == 'la' %} selected="selected"{% endif %}>Latina - la - Latin</option>
-	  <option value="mai"{% if text_language == 'mai' %} selected="selected"{% endif %}>মৈথিনী - mai - Maithili</option>
-	  <option value="mis-x-Q36846"{% if text_language == 'mis-x-Q36846' %} selected="selected"{% endif %}>Toki Pona - mis-x-Q36846 - Toki Pona</option>
-	  <option value="ml"{% if text_language == 'ml' %} selected="selected"{% endif %}>മലയാളം - ml - Malayalam</option>
-	  <option value="mn"{% if text_language == 'mn' %} selected="selected"{% endif %}>Монгол - mn - Mongolian</option>
-	  <option value="mr"{% if text_language == 'mr' %} selected="selected"{% endif %}>मराठी - mr - Marathi</option>
-	  <option value="nb"{% if text_language == 'nb' %} selected="selected"{% endif %}>norsk bokmål - nb - Norwegian Bokmål</option>
-	  <option value="ne"{% if text_language == 'ne' %} selected="selected"{% endif %}>नेपाली - ne - Nepali</option>
-	  <option value="nl"{% if text_language == 'nl' %} selected="selected"{% endif %}>Nederlands - nl - Dutch</option>
-	  <option value="nn"{% if text_language == 'nn' %} selected="selected"{% endif %}>norsk nynorsk - nn - Norwegian Nynorsk</option>
-	  <option value="nv"{% if text_language == 'nv' %} selected="selected"{% endif %}>Diné bizaad - nv - Navajo</option>
-	  <option value="or"{% if text_language == 'or' %} selected="selected"{% endif %}>ଓଡ଼ିଆ - or - Ordia</option>
-	  <option value="pa"{% if text_language == 'pa' %} selected="selected"{% endif %}>ਪੰਜਾਬੀ - pa - Punjabi Gurmukhi</option>
-	  <option value="pl"{% if text_language == 'pl' %} selected="selected"{% endif %}>Polski - pl - Polish</option>
-	  <option value="pnb"{% if text_language == 'pnb' %} selected="selected"{% endif %}>پن٘جابی - pnb - Punjabi Shahmukhi</option>
-	  <option value="pt"{% if text_language == 'pt' %} selected="selected"{% endif %}>Português - pt - Portuguese</option>
-	  <option value="ru"{% if text_language == 'ru' %} selected="selected"{% endif %}>Русский - ru - Russian</option>
-	  <option value="sk"{% if text_language == 'sk' %} selected="selected"{% endif %}>Slovenčina - sk - Slovak</option>
-	  <option value="sl"{% if text_language == 'sl' %} selected="selected"{% endif %}>Slovenščina - sl - Slovene</option>
-	  <option value="sv"{% if text_language == 'sv' %} selected="selected"{% endif %}>Svenska - sv - Swedish</option>
-	  <option value="sw"{% if text_language == 'sw' %} selected="selected"{% endif %}>Kiswahili - sw - Swahili</option>
-	  <option value="ta"{% if text_language == 'ta' %} selected="selected"{% endif %}>தமிழ் - ta - Tamil</option>
-	  <option value="te"{% if text_language == 'te' %} selected="selected"{% endif %}>తెలుగు - te - Telugu</option>
-	  <option value="tg"{% if text_language == 'tg' %} selected="selected"{% endif %}>Тоҷикӣ - tg - Tajik</option>
-	  <option value="tk"{% if text_language == 'tk' %} selected="selected"{% endif %}>Türkmençe - tk - Turkmen</option>
-	  <option value="ug"{% if text_language == 'ug' %} selected="selected"{% endif %}>ئۇيغۇرچە - ug - Uyghur</option>
-	  <option value="uk"{% if text_language == 'uk' %} selected="selected"{% endif %}>Українська - uk - Ukrainian</option>
-	  <option value="ur"{% if text_language == 'ur' %} selected="selected"{% endif %}>اُردُو - ur - Urdu</option>
-	  <option value="uz"{% if text_language == 'uz' %} selected="selected"{% endif %}>Oʻzbekcha - uz - Uzbek</option>
-	  <option value="vi"{% if text_language == 'vi' %} selected="selected"{% endif %}>Tiếng Việt - vi - Vietnamese</option>
-	  <option value="zh"{% if text_language == 'zh' %} selected="selected"{% endif %}>汉语 - zh - Chinese</option>
+        <label for="language">Language:</label>
+        <select class="form-control" id="language-selector" name="text-language">
+          {% for lang in languages | sort %}
+            <option value="{{ lang }}"{% if text_language == lang %} selected="selected"{% endif %}>
+            {% if languages[lang].autonym %}
+              {{ languages[lang].autonym }}
+            {% else %}
+              {{ languages[lang].name }}
+            {% endif %}
+            - {{ lang }} - {{ languages[lang].name }}
+            </option>
+          {% endfor %}
 	</select>
       </div>
       

--- a/ordia/app/views.py
+++ b/ordia/app/views.py
@@ -8,79 +8,48 @@ from werkzeug.routing import BaseConverter
 
 from six import u
 
-from ..api import wb_search_lexeme_entities
+from ..api import wb_search_lexeme_entities, wb_content_languages_cached
 from ..query import (escape_string, form_to_representation_and_iso639,
                      get_wikidata_language_codes_cached, iso639_to_q)
 from ..text import lowercase_first_sentence_letters, text_to_words
 
 
-ALLOWED_LANGUAGES = [
-    'aa', 'ab', 'ady', 'af', 'am', 'an', 'ang', 'ar', 'ar-x-q775724',
-    'arc', 'arz', 'as', 'ase', 'ase-x-q22001375', 'ast', 'atj', 'av',
-    'ay', 'az', 'az-x-q1828555', 'az-x-q8209', 'ba', 'bar', 'bcl',
-    'be', 'be-tarask', 'bg', 'bho', 'bi', 'bjn', 'bm', 'bn', 'bo',
-    'br', 'br-x-q2924576', 'br-x-q54555486', 'br-x-q54555509', 'bxr',
-    'ca', 'ca-x-q32641', 'ce', 'ceb', 'ch', 'chr', 'chy', 'ckb', 'co',
-    'cr', 'crh', 'crh-latn', 'crh-x-q38893333', 'crh-x-q39132363',
-    'cs', 'cs-x-q28861', 'cs-x-q9995', 'csb', 'cu', 'cu-x-q145625',
-    'cu-x-q8209', 'cv', 'cy', 'da', 'de', 'de-x-q306626',
-    'de-x-q35218', 'de-x-q837985', 'diq', 'dsb', 'dtp', 'dty', 'dv',
-    'egl', 'el', 'en', 'en-ca', 'en-gb', 'en-x-q1337', 'en-x-q44679',
-    'en-x-q7976', 'eo', 'eo-x-q3497763', 'eo-x-q3505590', 'es',
-    'es-419', 'es-x-q2034', 'es-x-q957764', 'et', 'eu',
-    'eu-x-q3125314', 'eu-x-q749166', 'ext', 'fa', 'ff', 'fi', 'fo',
-    'fr', 'fr-x-q35222', 'fr-x-q39', 'fr-x-q535', 'frr', 'fur', 'fy',
-    'ga', 'gag', 'gd', 'gl', 'gn', 'gom-deva', 'gom-latn', 'got',
-    'grc', 'gsw', 'gu', 'gv', 'ha', 'haw', 'he', 'he-x-q21283070',
-    'he-x-q2975864', 'he-x-q67200702', 'hi', 'hif', 'hr', 'hsb', 'ht',
-    'hu', 'hy', 'ia', 'id', 'id-x-q57549853', 'ie', 'ig', 'ii', 'ilo',
-    'inh', 'io', 'is', 'it', 'it-x-q672147', 'iu', 'iu-x-q2479183',
-    'iu-x-q8229', 'ja', 'ja-x-q10997505', 'ja-x-q53979341',
-    'ja-x-q53979348', 'ja-x-q82772', 'ja-x-q82946', 'jam', 'jbo',
-    'jv', 'jv-x-q879704', 'ka', 'kaa', 'kaa-x-q8209', 'kab', 'kbp',
-    'kg', 'ki', 'kk', 'kk-x-q64362991', 'kk-x-q64362992',
-    'kk-x-q64362993', 'kl', 'km', 'kn', 'ko', 'ko-x-q485619', 'koi',
-    'krc', 'ku', 'kv', 'kw', 'ky', 'la', 'la-x-q179230', 'lad',
-    'lad-x-q33513', 'lad-x-q8229', 'lb', 'lbe', 'lez', 'lfn', 'lg',
-    'li', 'lij', 'liv', 'lmo', 'ln', 'lo', 'lt', 'ltg', 'lv', 'mdf',
-    'mg', 'mhr', 'mi', 'min', 'mis', 'mis-x-q149838',
-    'mis-x-q16315466', 'mis-x-q179230', 'mis-x-q181074',
-    'mis-x-q208503', 'mis-x-q21117', 'mis-x-q21146257',
-    'mis-x-q2270532', 'mis-x-q2482781', 'mis-x-q27567',
-    'mis-x-q27969', 'mis-x-q3199353', 'mis-x-q33060', 'mis-x-q33161',
-    'mis-x-q33170', 'mis-x-q33537', 'mis-x-q33624', 'mis-x-q33690',
-    'mis-x-q33759', 'mis-x-q35222', 'mis-x-q35228', 'mis-x-q35241',
-    'mis-x-q35505', 'mis-x-q35527', 'mis-x-q3558112', 'mis-x-q35668',
-    'mis-x-q35726', 'mis-x-q36155', 'mis-x-q36395', 'mis-x-q36730',
-    'mis-x-q36741', 'mis-x-q36790', 'mis-x-q36819', 'mis-x-q36822',
-    'mis-x-Q36846',
-    'mis-x-q37178', 'mis-x-q3938', 'mis-x-q401', 'mis-x-q44679',
-    'mis-x-q47091826', 'mis-x-q505674', 'mis-x-q50868',
-    'mis-x-q533109', 'mis-x-q56384', 'mis-x-q56430', 'mis-x-q56485',
-    'mis-x-q56627865', 'mis-x-q56743290', 'mis-x-q666027',
-    'mis-x-q7249970', 'mis-x-q7251862', 'mis-x-q747537',
-    'mis-x-q787610', 'mis-x-q837985', 'mk', 'ml', 'mn',
-    'mn-x-q1055705', 'mr', 'ms', 'ms-x-q83942', 'mt', 'mwl', 'my',
-    'myv', 'mzn', 'na', 'nah', 'nan', 'nap', 'nb', 'nds', 'ne', 'new',
-    'nl', 'nn', 'no', 'nv', 'nys', 'oc', 'om', 'or', 'os', 'ota',
-    'pa', 'pam', 'pap', 'pdc', 'pl', 'pl-x-q101244', 'pl-x-q180309',
-    'pl-x-q98912', 'pms', 'pnb', 'prg', 'ps', 'pt', 'pt-br', 'qu',
-    'rm', 'rm-sursilv', 'rm-sutsilv', 'rm-vallader', 'rmy', 'ro',
-    'ru', 'ru-x-q2442696', 'rue', 'sa', 'sah', 'sc', 'scn', 'sco',
-    'sd', 'se', 'se-x-q56681944', 'se-x-q56681946', 'sgs', 'sh',
-    'sh-x-q8229', 'shy-latn', 'si', 'sk', 'sl', 'sm', 'sma', 'smj',
-    'smn', 'sms', 'sn', 'so', 'sq', 'sr', 'sr-ec', 'sr-el', 'srn',
-    'st', 'st-x-q1013', 'st-x-q258', 'stq', 'su', 'sv', 'sw', 'szl',
-    'ta', 'tcy', 'te', 'tet', 'tg', 'th', 'tk', 'tk-x-q8209',
-    'tk-x-q8229', 'tl', 'tly-x-q8209', 'tly-x-q8229', 'tr', 'ts',
-    'tt', 'tw', 'tyv', 'udm', 'ug', 'ug-latn', 'ug-x-q11084133',
-    'ug-x-q6672247', 'ug-x-q986283', 'uk', 'ur', 'uz',
-    'uz-x-q64363006', 'uz-x-q64363007', 'vec', 'vep', 'vi', 'vls',
-    'vo', 'vo-x-q12712', 'vot', 'vro', 'wa', 'war', 'wo', 'xal', 'xh',
-    'xmf', 'yi', 'yi-x-q188725', 'yo', 'yue', 'za', 'za-x-q58349204',
-    'zh', 'zh-cn', 'zh-hans', 'zh-hant', 'zh-tw', 'zh-x-q178528',
-    'zu']
 
+ALLOWED_LANGUAGES = list(wb_content_languages_cached()) + [
+    'ar-x-q775724', 'ase-x-q22001375', 'az-x-q1828555', 'az-x-q8209',
+    'br-x-q2924576', 'br-x-q54555486', 'br-x-q54555509', 'ca-x-q32641',
+    'crh-x-q38893333', 'crh-x-q39132363','cs-x-q28861', 'cs-x-q9995',
+    'cu-x-q145625', 'cu-x-q8209', 'de-x-q306626', 'de-x-q35218',
+    'de-x-q837985', 'en-x-q1337', 'en-x-q44679', 'en-x-q7976',
+    'eo-x-q3497763', 'eo-x-q3505590', 'es-x-q2034', 'es-x-q957764',
+    'eu-x-q3125314', 'eu-x-q749166', 'fr-x-q35222', 'fr-x-q39',
+    'fr-x-q535', 'he-x-q21283070', 'he-x-q2975864', 'he-x-q67200702',
+    'id-x-q57549853', 'it-x-q672147', 'iu-x-q2479183', 'iu-x-q8229',
+    'ja-x-q10997505', 'ja-x-q53979341', 'ja-x-q53979348', 'ja-x-q82772',
+    'ja-x-q82946', 'jv-x-q879704', 'kaa-x-q8209', 'kk-x-q64362991',
+    'kk-x-q64362992', 'kk-x-q64362993', 'ko-x-q485619', 'la-x-q179230',
+    'lad-x-q33513', 'lad-x-q8229', 'mis-x-q149838', 'mis-x-q16315466',
+    'mis-x-q179230', 'mis-x-q181074', 'mis-x-q208503', 'mis-x-q21117',
+    'mis-x-q21146257', 'mis-x-q2270532', 'mis-x-q2482781',
+    'mis-x-q27567', 'mis-x-q27969', 'mis-x-q3199353', 'mis-x-q33060',
+    'mis-x-q33161', 'mis-x-q33170', 'mis-x-q33537', 'mis-x-q33624',
+    'mis-x-q33690', 'mis-x-q33759', 'mis-x-q35222', 'mis-x-q35228',
+    'mis-x-q35241', 'mis-x-q35505', 'mis-x-q35527', 'mis-x-q3558112',
+    'mis-x-q35668', 'mis-x-q35726', 'mis-x-q36155', 'mis-x-q36395',
+    'mis-x-q36730', 'mis-x-q36741', 'mis-x-q36790', 'mis-x-q36819',
+    'mis-x-q36822', 'mis-x-Q36846', 'mis-x-q37178', 'mis-x-q3938',
+    'mis-x-q401', 'mis-x-q44679', 'mis-x-q47091826', 'mis-x-q505674',
+    'mis-x-q50868', 'mis-x-q533109', 'mis-x-q56384', 'mis-x-q56430',
+    'mis-x-q56485', 'mis-x-q56627865', 'mis-x-q56743290',
+    'mis-x-q666027', 'mis-x-q7249970', 'mis-x-q7251862',
+    'mis-x-q747537', 'mis-x-q787610', 'mis-x-q837985',
+    'mn-x-q1055705', 'ms-x-q83942', 'pl-x-q101244', 'pl-x-q180309',
+    'pl-x-q98912', 'ru-x-q2442696', 'se-x-q56681944', 'se-x-q56681946',
+    'sh-x-q8229', 'st-x-q1013', 'st-x-q258', 'tk-x-q8209',
+    'tk-x-q8229', 'tly-x-q8209', 'tly-x-q8229', 'ug-x-q11084133',
+    'ug-x-q6672247', 'ug-x-q986283', 'uz-x-q64363006',
+    'uz-x-q64363007', 'vo-x-q12712', 'yi-x-q188725', 'za-x-q58349204',
+    'zh-x-q178528']
 
 class RegexConverter(BaseConverter):
     """Converter for regular expression routes.
@@ -564,10 +533,12 @@ def show_text_to_lexemes():
         casing = 'lowercase_first_sentence_letters'
     casing = casing.replace('-', '_')
 
+    languages = wb_content_languages_cached()
+
     if not text:
         return render_template('text_to_lexemes.html',
                                text_language=text_language,
-                               casing=casing)
+                               casing=casing, languages=languages)
 
     # Casing processing
     cased_text = text.strip()
@@ -597,4 +568,4 @@ def show_text_to_lexemes():
             word=word, language=text_language)
 
     return render_template('text_to_lexemes.html', text=text, words=words,
-                           text_language=text_language, casing=casing)
+                           text_language=text_language, casing=casing, languages=languages)


### PR DESCRIPTION
This adds two functions, `wb_content_languages()` and `wb_content_languages_cached()`, to api.py. These fetch the current list of lexeme languages from the Wikidata API so that text-to-lexemes can be used for all defined language codes. Custom language codes (those with `-x-QID`) are still not supported.

The caching copies the approach used in query.py, except with `maxsize` set to `None` because the function doesn't take any arguments. A usage-based cache is not ideal here, because that will probably mean the list will be cached indefinitely until the server is restarted, but this would still be an improvement over the current situation where the list stays the same until someone sends a pull request. A time-based cache would be better, since the list will only change when newer versions of MediaWiki/Wikibase are deployed. I haven't done that myself though because I'm not very familiar with Python or caching.

All of the current entries in text_to_lexemes.html are in the list returned from the API, except for `mis-x-Q36846`, which is no longer necessary because that code has since been replaced by `tok`.