### PR TITLE
Round the average number of statements to at most 2 decimal places

### DIFF
--- a/ordia/app/templates/language_index.html
+++ b/ordia/app/templates/language_index.html
@@ -33,7 +33,7 @@ WHERE {
     SELECT
       ?language
       (SUM(?statements) AS ?total_number_of_statements)
-      (AVG(?statements) AS ?average_number_of_statements)
+      (ROUND(AVG(?statements)*100)/100 AS ?average_number_of_statements)
     {
       [] wikibase:statements ?statements ;
          dct:language ?language .


### PR DESCRIPTION
The default behaviour produces numbers with 20 decimal places, which is excessive in this context. Rounding to at most 2 decimal places produces more reasonable results. Since SPARQL can only round to the nearest integer, the value is multiplied by 100 before rounding and then divided by 100 afterwards. Values with fewer decimal places will not change.

Example values before and after this change:
* 17.91454359739928107014 → 17.91
* 4.92922500540358798242 → 4.93
* 0.5 → 0.5
* 1 → 1