### PR TITLE
Fix #264 tweak guess-word-from-image

### DIFF
--- a/ordia/app/templates/guess-word-from-image.html
+++ b/ordia/app/templates/guess-word-from-image.html
@@ -75,7 +75,7 @@
               BIND(CONCAT(?image_https, "?width=300") AS ?image_url)
             }
             GROUP BY ?lexeme ?gloss ?image_url
-            LIMIT 1000
+            LIMIT 10000
             `;
             const url = SPARQL_ENDPOINT + '?query=' + encodeURIComponent(query);
 


### PR DESCRIPTION
Changed LIMIT in SPARQL query to get move diverse set of word-image pairs.