### PR TITLE
Fix #285 guess-the-gender multiple gender

### DIFF
--- a/ordia/app/templates/guess-the-gender.html
+++ b/ordia/app/templates/guess-the-gender.html
@@ -82,7 +82,7 @@
                 INCLUDE %lexemes
                 ?lexeme wikibase:lemma ?lemma_ .
               }
-              GROUP BY ?lexeme ?gender_
+              GROUP BY ?lexeme
               HAVING (COUNT(DISTINCT ?gender_) = 1)
               LIMIT 100
             `


### PR DESCRIPTION
If a lexeme had multiple genders it was not filtered out.